### PR TITLE
Fix image on click feature

### DIFF
--- a/templates/listing.html
+++ b/templates/listing.html
@@ -18,7 +18,7 @@
             <div class='row'>
                 {% for photo in listing['photos']%}
                 <a target="_blank" href={{photo[1]}}>
-                    <img src={{photo[1]}} style="max-width: 220px; max-height: 150px; width: auto; height: auto;"></a>
+                    <img src={{photo[1]}} style="padding: 10px; max-width: 220px; max-height: 220px; width: auto; height: auto;"></a>
                 {%endfor%}
 
             </div>


### PR DESCRIPTION
Upon click of the image, it pops out a new window for the user to take a closer look at the image, instead of a weirdly sized modal preview.

https://user-images.githubusercontent.com/66056519/135512050-19001ec6-fcdb-4d09-be28-17abcbea8e20.mov



